### PR TITLE
Add paymentMethodDetails to transactionCreate

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/shared.py
+++ b/saleor/graphql/payment/mutations/transaction/shared.py
@@ -1,0 +1,228 @@
+import graphene
+from django.core.exceptions import ValidationError
+
+from .....payment import PaymentMethodType
+from .....payment.error_codes import (
+    TransactionCreateErrorCode,
+    TransactionEventReportErrorCode,
+    TransactionUpdateErrorCode,
+)
+from .....payment.interface import PaymentMethodDetails
+from ....core.descriptions import ADDED_IN_322
+from ....core.types.base import BaseInputObjectType
+from ....core.validators import validate_one_of_args_is_in_mutation
+
+
+class CardPaymentMethodDetailsInput(BaseInputObjectType):
+    name = graphene.String(
+        description="Name of the payment method used for the transaction. Max length is 256 characters.",
+        required=True,
+    )
+    brand = graphene.String(
+        description="Brand of the payment method used for the transaction. Max length is 40 characters.",
+        required=False,
+    )
+    first_digits = graphene.String(
+        description="First digits of the card used for the transaction. Max length is 4 characters.",
+        required=False,
+    )
+    last_digits = graphene.String(
+        description="Last digits of the card used for the transaction. Max length is 4 characters.",
+        required=False,
+    )
+    exp_month = graphene.Int(
+        description="Expiration month of the card used for the transaction. Value must be between 1 and 12.",
+        required=False,
+    )
+    exp_year = graphene.Int(
+        description="Expiration year of the card used for the transaction. Value must be between 2000 and 9999.",
+        required=False,
+    )
+
+
+class OtherPaymentMethodDetailsInput(BaseInputObjectType):
+    name = graphene.String(
+        description="Name of the payment method used for the transaction.",
+        required=True,
+    )
+
+
+class PaymentMethodDetailsInput(BaseInputObjectType):
+    card = graphene.Field(
+        CardPaymentMethodDetailsInput,
+        required=False,
+        description="Details of the card payment method used for the transaction.",
+    )
+    other = graphene.Field(
+        OtherPaymentMethodDetailsInput,
+        required=False,
+        description="Details of the non-card payment method used for this transaction.",
+    )
+
+    class Meta:
+        description = (
+            "Details of the payment method used for the transaction. "
+            "One of `card` or `other` is required." + ADDED_IN_322
+        )
+
+
+def validate_card_payment_method_details_input(
+    card_method_details_input: CardPaymentMethodDetailsInput,
+    error_code_class: type[TransactionEventReportErrorCode]
+    | type[TransactionCreateErrorCode]
+    | type[TransactionUpdateErrorCode],
+):
+    errors = []
+    if len(card_method_details_input.name) > 256:
+        errors.append(
+            {
+                "name": ValidationError(
+                    "The `name` field must be less than 256 characters.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+
+    if card_method_details_input.brand and len(card_method_details_input.brand) > 40:
+        errors.append(
+            {
+                "brand": ValidationError(
+                    "The `brand` field must be less than 40 characters.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+    if (
+        card_method_details_input.first_digits
+        and len(card_method_details_input.first_digits) > 4
+    ):
+        errors.append(
+            {
+                "first_digits": ValidationError(
+                    "The `firstDigits` field must be less than 4 characters.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+    if (
+        card_method_details_input.last_digits
+        and len(card_method_details_input.last_digits) > 4
+    ):
+        errors.append(
+            {
+                "last_digits": ValidationError(
+                    "The `lastDigits` field must be less than 4 characters.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+    if card_method_details_input.exp_month and (
+        card_method_details_input.exp_month < 1
+        or card_method_details_input.exp_month > 12
+    ):
+        errors.append(
+            {
+                "exp_month": ValidationError(
+                    "The `expMonth` field must be between 1 and 12.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+    if card_method_details_input.exp_year and (
+        card_method_details_input.exp_year < 2000
+        or card_method_details_input.exp_year > 9999
+    ):
+        errors.append(
+            {
+                "exp_year": ValidationError(
+                    "The `expYear` field must be between 2000 and 9999.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+    return errors
+
+
+def validate_payment_method_details_input(
+    payment_method_details_input: PaymentMethodDetailsInput,
+    error_code_class: type[TransactionEventReportErrorCode]
+    | type[TransactionCreateErrorCode]
+    | type[TransactionUpdateErrorCode],
+):
+    if (
+        payment_method_details_input.card is None
+        and payment_method_details_input.other is None
+    ):
+        raise ValidationError(
+            {
+                "payment_method_details": ValidationError(
+                    "One of `card` or `other` is required.",
+                    code=error_code_class.INVALID.value,
+                )
+            }
+        )
+    try:
+        validate_one_of_args_is_in_mutation(
+            "card",
+            payment_method_details_input.card,
+            "other",
+            payment_method_details_input.other,
+        )
+    except ValidationError as e:
+        e.code = error_code_class.INVALID.value
+        raise ValidationError({"payment_method_details": e}) from e
+
+    errors = []
+
+    if payment_method_details_input.card:
+        errors.extend(
+            validate_card_payment_method_details_input(
+                payment_method_details_input.card, error_code_class
+            )
+        )
+    elif payment_method_details_input.other:
+        if len(payment_method_details_input.other.name) > 256:
+            errors.append(
+                {
+                    "name": ValidationError(
+                        "The `name` field must be less than 256 characters.",
+                        code=error_code_class.INVALID.value,
+                    )
+                }
+            )
+
+    if errors:
+        raise ValidationError({"payment_method_details": errors})
+
+
+def get_payment_method_details(
+    payment_method_details_input: PaymentMethodDetailsInput | None,
+) -> PaymentMethodDetails | None:
+    """Get the payment method details dataclass from the input."""
+
+    if not payment_method_details_input:
+        return None
+
+    payment_details_data: PaymentMethodDetails | None = None
+    if payment_method_details_input.card:
+        card_details: CardPaymentMethodDetailsInput = payment_method_details_input.card
+
+        payment_details_data = PaymentMethodDetails(
+            type=PaymentMethodType.CARD,
+            name=card_details.name,
+            brand=card_details.brand,
+            first_digits=card_details.first_digits,
+            last_digits=card_details.last_digits,
+            exp_month=card_details.exp_month,
+            exp_year=card_details.exp_year,
+        )
+    elif payment_method_details_input.other:
+        other_details: OtherPaymentMethodDetailsInput = (
+            payment_method_details_input.other
+        )
+        payment_details_data = PaymentMethodDetails(
+            type=PaymentMethodType.OTHER,
+            name=other_details.name,
+        )
+
+    return payment_details_data

--- a/saleor/graphql/payment/mutations/transaction/transaction_create.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_create.py
@@ -20,14 +20,17 @@ from .....order.utils import update_order_status, updates_amounts_for_order
 from .....payment import TransactionEventType
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionCreateErrorCode
+from .....payment.interface import PaymentMethodDetails
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
 from .....payment.utils import (
     create_manual_adjustment_events,
     truncate_transaction_event_message,
+    update_transaction_item_with_payment_method_details,
 )
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_322
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.mutations import BaseMutation
 from ....core.types import BaseInputObjectType
@@ -38,6 +41,11 @@ from ...enums import TransactionActionEnum
 from ...types import TransactionItem
 from ...utils import deprecated_metadata_contains_empty_key
 from ..payment.payment_check_balance import MoneyInput
+from .shared import (
+    PaymentMethodDetailsInput,
+    get_payment_method_details,
+    validate_payment_method_details_input,
+)
 
 
 class TransactionCreateInput(BaseInputObjectType):
@@ -72,6 +80,11 @@ class TransactionCreateInput(BaseInputObjectType):
             "The url that will allow to redirect user to "
             "payment provider page with transaction event details."
         )
+    )
+    payment_method_details = PaymentMethodDetailsInput(
+        description="Details of the payment method used for the transaction."
+        + ADDED_IN_322,
+        required=False,
     )
 
     class Meta:
@@ -251,13 +264,23 @@ class TransactionCreate(BaseMutation):
             transaction.get("external_url"),
             error_code=TransactionCreateErrorCode.INVALID.value,
         )
+        if payment_method_details := transaction.get("payment_method_details"):
+            validate_payment_method_details_input(
+                payment_method_details, TransactionCreateErrorCode
+            )
+
         if "available_actions" in transaction and not transaction["available_actions"]:
             transaction.pop("available_actions")
         return instance
 
     @classmethod
     def create_transaction(
-        cls, transaction_input: dict, user, app, save: bool = True
+        cls,
+        transaction_input: dict,
+        user,
+        app,
+        save: bool = True,
+        payment_details_data: PaymentMethodDetails | None = None,
     ) -> payment_models.TransactionItem:
         app_identifier = None
         if app and app.identifier:
@@ -275,6 +298,10 @@ class TransactionCreate(BaseMutation):
             app_identifier=app_identifier,
             app=app,
         )
+        if payment_details_data:
+            update_transaction_item_with_payment_method_details(
+                transaction, payment_details_data
+            )
         cls.cleanup_and_update_metadata_data(transaction, metadata, private_metadata)
         if save:
             transaction.save()
@@ -355,6 +382,10 @@ class TransactionCreate(BaseMutation):
         order_or_checkout_instance = cls.validate_input(
             order_or_checkout_instance, transaction=transaction
         )
+        payment_details_data: PaymentMethodDetails | None = None
+        if payment_method_details := transaction.pop("payment_method_details", None):
+            payment_details_data = get_payment_method_details(payment_method_details)
+
         transaction_data = {**transaction}
         currency = order_or_checkout_instance.currency
         transaction_data["currency"] = currency
@@ -375,7 +406,12 @@ class TransactionCreate(BaseMutation):
                     message=transaction_event.get("message", ""),
                 )
         money_data = cls.get_money_data_from_input(transaction_data, currency)
-        new_transaction = cls.create_transaction(transaction_data, user=user, app=app)
+        new_transaction = cls.create_transaction(
+            transaction_data,
+            user=user,
+            app=app,
+            payment_details_data=payment_details_data,
+        )
         if money_data:
             create_manual_adjustment_events(
                 transaction=new_transaction, money_data=money_data, user=user, app=app

--- a/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_event_report.py
@@ -22,7 +22,7 @@ from .....order.utils import (
     calculate_order_granted_refund_status,
     updates_amounts_for_order,
 )
-from .....payment import OPTIONAL_AMOUNT_EVENTS, PaymentMethodType, TransactionEventType
+from .....payment import OPTIONAL_AMOUNT_EVENTS, TransactionEventType
 from .....payment import models as payment_models
 from .....payment.interface import PaymentMethodDetails
 from .....payment.transaction_item_calculations import recalculate_transaction_amounts
@@ -46,7 +46,6 @@ from ....core.mutations import DeprecatedModelMutation
 from ....core.scalars import UUID, DateTime, PositiveDecimal
 from ....core.types import NonNullList
 from ....core.types import common as common_types
-from ....core.types.base import BaseInputObjectType
 from ....core.utils import WebhookEventInfo
 from ....core.validators import validate_one_of_args_is_in_mutation
 from ....meta.inputs import MetadataInput, MetadataInputDescription
@@ -54,64 +53,16 @@ from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import TransactionActionEnum, TransactionEventTypeEnum
 from ...types import TransactionEvent, TransactionItem
 from ...utils import check_if_requestor_has_access
+from .shared import (
+    PaymentMethodDetailsInput,
+    get_payment_method_details,
+    validate_payment_method_details_input,
+)
 from .utils import get_transaction_item
 
 if TYPE_CHECKING:
     from .....accounts.models import User
     from .....plugins.manager import PluginsManager
-
-
-class CardPaymentMethodDetailsInput(BaseInputObjectType):
-    name = graphene.String(
-        description="Name of the payment method used for the transaction. Max length is 256 characters.",
-        required=True,
-    )
-    brand = graphene.String(
-        description="Brand of the payment method used for the transaction. Max length is 40 characters.",
-        required=False,
-    )
-    first_digits = graphene.String(
-        description="First digits of the card used for the transaction. Max length is 4 characters.",
-        required=False,
-    )
-    last_digits = graphene.String(
-        description="Last digits of the card used for the transaction. Max length is 4 characters.",
-        required=False,
-    )
-    exp_month = graphene.Int(
-        description="Expiration month of the card used for the transaction. Value must be between 1 and 12.",
-        required=False,
-    )
-    exp_year = graphene.Int(
-        description="Expiration year of the card used for the transaction. Value must be between 2000 and 9999.",
-        required=False,
-    )
-
-
-class OtherPaymentMethodDetailsInput(BaseInputObjectType):
-    name = graphene.String(
-        description="Name of the payment method used for the transaction.",
-        required=True,
-    )
-
-
-class PaymentMethodDetailsInput(BaseInputObjectType):
-    card = graphene.Field(
-        CardPaymentMethodDetailsInput,
-        required=False,
-        description="Details of the card payment method used for the transaction.",
-    )
-    other = graphene.Field(
-        OtherPaymentMethodDetailsInput,
-        required=False,
-        description="Details of the non-card payment method used for this transaction.",
-    )
-
-    class Meta:
-        description = (
-            "Details of the payment method used for the transaction. "
-            "One of `card` or `other` is required." + ADDED_IN_322
-        )
 
 
 class TransactionEventReport(DeprecatedModelMutation):
@@ -430,155 +381,6 @@ class TransactionEventReport(DeprecatedModelMutation):
             )
 
     @classmethod
-    def _validate_card_payment_method_details_input(
-        cls, card_method_details_input: CardPaymentMethodDetailsInput
-    ):
-        errors = []
-        if len(card_method_details_input.name) > 256:
-            errors.append(
-                {
-                    "name": ValidationError(
-                        "The `name` field must be less than 256 characters.",
-                        code=TransactionEventReportErrorCode.INVALID.value,
-                    )
-                }
-            )
-
-        if (
-            card_method_details_input.brand
-            and len(card_method_details_input.brand) > 40
-        ):
-            errors.append(
-                {
-                    "brand": ValidationError(
-                        "The `brand` field must be less than 40 characters.",
-                        code=TransactionEventReportErrorCode.INVALID.value,
-                    )
-                }
-            )
-        if (
-            card_method_details_input.first_digits
-            and len(card_method_details_input.first_digits) > 4
-        ):
-            errors.append(
-                {
-                    "first_digits": ValidationError(
-                        "The `firstDigits` field must be less than 4 characters.",
-                        code=TransactionEventReportErrorCode.INVALID.value,
-                    )
-                }
-            )
-        if (
-            card_method_details_input.last_digits
-            and len(card_method_details_input.last_digits) > 4
-        ):
-            errors.append(
-                {
-                    "last_digits": ValidationError(
-                        "The `lastDigits` field must be less than 4 characters.",
-                        code=TransactionEventReportErrorCode.INVALID.value,
-                    )
-                }
-            )
-        if card_method_details_input.exp_month and (
-            card_method_details_input.exp_month < 1
-            or card_method_details_input.exp_month > 12
-        ):
-            errors.append(
-                {
-                    "exp_month": ValidationError(
-                        "The `expMonth` field must be between 1 and 12.",
-                        code=TransactionEventReportErrorCode.INVALID.value,
-                    )
-                }
-            )
-        if card_method_details_input.exp_year and (
-            card_method_details_input.exp_year < 2000
-            or card_method_details_input.exp_year > 9999
-        ):
-            errors.append(
-                {
-                    "exp_year": ValidationError(
-                        "The `expYear` field must be between 2000 and 9999.",
-                        code=TransactionEventReportErrorCode.INVALID.value,
-                    )
-                }
-            )
-        return errors
-
-    @classmethod
-    def validate_payment_method_details_input(
-        cls, payment_method_details_input: PaymentMethodDetailsInput
-    ):
-        try:
-            validate_one_of_args_is_in_mutation(
-                "card",
-                payment_method_details_input.card,
-                "other",
-                payment_method_details_input.other,
-            )
-        except ValidationError as e:
-            e.code = TransactionEventReportErrorCode.INVALID.value
-            raise ValidationError({"payment_method_details": e}) from e
-
-        errors = []
-
-        if payment_method_details_input.card:
-            errors.extend(
-                cls._validate_card_payment_method_details_input(
-                    payment_method_details_input.card
-                )
-            )
-        elif payment_method_details_input.other:
-            if len(payment_method_details_input.other.name) > 256:
-                errors.append(
-                    {
-                        "name": ValidationError(
-                            "The `name` field must be less than 256 characters.",
-                            code=TransactionEventReportErrorCode.INVALID.value,
-                        )
-                    }
-                )
-
-        if errors:
-            raise ValidationError({"payment_method_details": errors})
-
-    @classmethod
-    def get_payment_method_details(
-        cls, payment_method_details_input: PaymentMethodDetailsInput | None
-    ) -> PaymentMethodDetails | None:
-        """Get the payment method details dataclass from the input."""
-
-        if not payment_method_details_input:
-            return None
-
-        payment_details_data: PaymentMethodDetails | None = None
-        if payment_method_details_input.card:
-            card_details: CardPaymentMethodDetailsInput = (
-                payment_method_details_input.card
-            )
-
-            payment_details_data = PaymentMethodDetails(
-                type=PaymentMethodType.CARD,
-                name=card_details.name,
-                brand=card_details.brand,
-                first_digits=card_details.first_digits,
-                last_digits=card_details.last_digits,
-                exp_month=card_details.exp_month,
-                exp_year=card_details.exp_year,
-            )
-        elif payment_method_details_input.other:
-            other_details: OtherPaymentMethodDetailsInput = (
-                payment_method_details_input.other
-            )
-            payment_details_data = PaymentMethodDetails(
-                type=PaymentMethodType.OTHER,
-                name=other_details.name,
-            )
-
-        return payment_details_data
-
-    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls,
         root,
@@ -629,10 +431,10 @@ class TransactionEventReport(DeprecatedModelMutation):
 
         payment_details_data: PaymentMethodDetails | None = None
         if payment_method_details:
-            cls.validate_payment_method_details_input(payment_method_details)
-            payment_details_data = cls.get_payment_method_details(
-                payment_method_details
+            validate_payment_method_details_input(
+                payment_method_details, TransactionEventReportErrorCode
             )
+            payment_details_data = get_payment_method_details(payment_method_details)
 
         message = (
             truncate_transaction_event_message(message) if message is not None else ""

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -12,7 +12,7 @@ from .....checkout.models import Checkout
 from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderEvents, OrderStatus
 from .....order.models import Order
 from .....order.utils import update_order_authorize_data, update_order_charge_data
-from .....payment import TransactionEventType
+from .....payment import PaymentMethodType, TransactionEventType
 from .....payment.error_codes import TransactionCreateErrorCode
 from .....payment.models import TransactionItem
 from ....core.utils import to_global_id_or_none
@@ -61,6 +61,21 @@ mutation TransactionCreate(
                     }
                     ... on App {
                         id
+                    }
+                }
+                paymentMethodDetails{
+                    ...on CardPaymentMethodDetails{
+                        __typename
+                        name
+                        brand
+                        firstDigits
+                        lastDigits
+                        expMonth
+                        expYear
+                    }
+                    ...on OtherPaymentMethodDetails{
+                        __typename
+                        name
                     }
                 }
                 events{
@@ -2466,3 +2481,307 @@ def test_transaction_create_create_event_message_is_empty(
     event = transaction.events.last()
     assert event.message == ""
     assert event.psp_reference == transaction_reference
+
+
+@pytest.mark.parametrize(
+    (
+        "card_brand",
+        "card_first_digits",
+        "card_last_digits",
+        "card_exp_month",
+        "card_exp_year",
+    ),
+    [
+        ("Brand", "1234", "5678", 12, 2025),
+        (None, "1111", "0000", 1, 2001),
+        (None, None, None, None, None),
+        ("", "", "", None, None),
+        (None, None, "1234", None, None),
+    ],
+)
+def test_transaction_create_with_card_payment_method_details(
+    card_brand,
+    card_first_digits,
+    card_last_digits,
+    card_exp_month,
+    card_exp_year,
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+
+    authorized_value = Decimal("10")
+
+    card_name = "Payment Method Name"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "paymentMethodDetails": {
+                "card": {
+                    "name": card_name,
+                    "brand": card_brand,
+                    "firstDigits": card_first_digits,
+                    "lastDigits": card_last_digits,
+                    "expMonth": card_exp_month,
+                    "expYear": card_exp_year,
+                }
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    transaction = order_with_lines.payment_transactions.first()
+    content = get_graphql_content(response)
+    transaction_data = content["data"]["transactionCreate"]["transaction"]
+    assert transaction_data
+    assert not content["data"]["transactionCreate"]["errors"]
+
+    payment_method_details_data = transaction_data["paymentMethodDetails"]
+    assert payment_method_details_data["__typename"] == "CardPaymentMethodDetails"
+    assert payment_method_details_data["name"] == card_name
+    assert payment_method_details_data["brand"] == card_brand
+    assert payment_method_details_data["firstDigits"] == card_first_digits
+    assert payment_method_details_data["lastDigits"] == card_last_digits
+    assert payment_method_details_data["expMonth"] == card_exp_month
+    assert payment_method_details_data["expYear"] == card_exp_year
+
+    assert transaction.payment_method_type == PaymentMethodType.CARD
+    assert transaction.payment_method_name == card_name
+    assert transaction.cc_brand == card_brand
+    assert transaction.cc_first_digits == card_first_digits
+    assert transaction.cc_last_digits == card_last_digits
+    assert transaction.cc_exp_month == card_exp_month
+    assert transaction.cc_exp_year == card_exp_year
+
+
+def test_transaction_create_with_other_payment_method_details(
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+
+    authorized_value = Decimal("10")
+
+    other_name = "Payment Method Name"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "paymentMethodDetails": {
+                "other": {
+                    "name": other_name,
+                }
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    transaction = order_with_lines.payment_transactions.first()
+    content = get_graphql_content(response)
+    transaction_data = content["data"]["transactionCreate"]["transaction"]
+    assert transaction_data
+    assert not content["data"]["transactionCreate"]["errors"]
+
+    payment_method_details_data = transaction_data["paymentMethodDetails"]
+    assert payment_method_details_data["__typename"] == "OtherPaymentMethodDetails"
+    assert payment_method_details_data["name"] == other_name
+
+    transaction.refresh_from_db()
+    assert transaction.payment_method_type == PaymentMethodType.OTHER
+    assert transaction.payment_method_name == other_name
+    assert transaction.cc_brand is None
+    assert transaction.cc_first_digits is None
+    assert transaction.cc_last_digits is None
+    assert transaction.cc_exp_month is None
+    assert transaction.cc_exp_year is None
+
+
+def test_transaction_create_with_both_payment_method_details_inputs(
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+
+    authorized_value = Decimal("10")
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "paymentMethodDetails": {
+                "other": {
+                    "name": "Other",
+                },
+                "card": {
+                    "name": "Name",
+                },
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_data = response["data"]["transactionCreate"]
+    assert transaction_data["errors"]
+    assert len(transaction_data["errors"]) == 1
+    assert transaction_data["errors"][0]["code"] == "INVALID"
+
+
+@pytest.mark.parametrize(
+    (
+        "card_brand_length",
+        "card_first_digits",
+        "card_last_digits",
+        "card_exp_month",
+        "card_exp_year",
+        "card_name_length",
+    ),
+    [
+        (41, "12345", "56780", 33, 12025, 257),
+        (41, None, None, None, None, None),
+        (None, "12345", None, None, None, None),
+        (None, None, "56780", None, None, None),
+        (None, None, None, 33, None, None),
+        (None, None, None, None, 12025, None),
+        (None, None, None, None, None, 257),
+    ],
+)
+def test_transaction_create_with_invalid_card_payment_method_details(
+    card_brand_length,
+    card_first_digits,
+    card_last_digits,
+    card_exp_month,
+    card_exp_year,
+    card_name_length,
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+
+    authorized_value = Decimal("10")
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "paymentMethodDetails": {
+                "card": {
+                    "name": "N" * (card_name_length or 0),
+                    "brand": "B" * (card_brand_length or 0),
+                    "firstDigits": card_first_digits,
+                    "lastDigits": card_last_digits,
+                    "expMonth": card_exp_month,
+                    "expYear": card_exp_year,
+                }
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_data = response["data"]["transactionCreate"]
+    assert transaction_data["errors"]
+
+    for error in transaction_data["errors"]:
+        assert error["code"] == "INVALID"
+        assert error["field"] == "paymentMethodDetails"
+
+
+def test_transaction_create_with_invalid_other_payment_method_details(
+    order_with_lines,
+    permission_manage_payments,
+    app_api_client,
+):
+    # given
+    name = "Credit Card"
+    psp_reference = "PSP reference - 123"
+
+    authorized_value = Decimal("10")
+
+    other_name = "Payment Method Name"
+
+    variables = {
+        "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
+        "transaction": {
+            "name": name,
+            "pspReference": psp_reference,
+            "amountAuthorized": {
+                "amount": authorized_value,
+                "currency": "USD",
+            },
+            "paymentMethodDetails": {
+                "other": {
+                    "name": other_name * 256,
+                }
+            },
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_CREATE, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_data = response["data"]["transactionCreate"]
+    assert transaction_data["errors"]
+    assert len(transaction_data["errors"]) == 1
+    error = transaction_data["errors"][0]
+    assert error["code"] == "INVALID"
+    assert error["field"] == "paymentMethodDetails"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22705,6 +22705,63 @@ input TransactionCreateInput @doc(category: "Payments") {
   The url that will allow to redirect user to payment provider page with transaction event details.
   """
   externalUrl: String
+
+  """
+  Details of the payment method used for the transaction.
+  
+  Added in Saleor 3.22.
+  """
+  paymentMethodDetails: PaymentMethodDetailsInput
+}
+
+"""
+Details of the payment method used for the transaction. One of `card` or `other` is required.
+
+Added in Saleor 3.22.
+"""
+input PaymentMethodDetailsInput {
+  """Details of the card payment method used for the transaction."""
+  card: CardPaymentMethodDetailsInput
+
+  """Details of the non-card payment method used for this transaction."""
+  other: OtherPaymentMethodDetailsInput
+}
+
+input CardPaymentMethodDetailsInput {
+  """
+  Name of the payment method used for the transaction. Max length is 256 characters.
+  """
+  name: String!
+
+  """
+  Brand of the payment method used for the transaction. Max length is 40 characters.
+  """
+  brand: String
+
+  """
+  First digits of the card used for the transaction. Max length is 4 characters.
+  """
+  firstDigits: String
+
+  """
+  Last digits of the card used for the transaction. Max length is 4 characters.
+  """
+  lastDigits: String
+
+  """
+  Expiration month of the card used for the transaction. Value must be between 1 and 12.
+  """
+  expMonth: Int
+
+  """
+  Expiration year of the card used for the transaction. Value must be between 2000 and 9999.
+  """
+  expYear: Int
+}
+
+input OtherPaymentMethodDetailsInput {
+  """Name of the payment method used for the transaction."""
+  name: String!
 }
 
 input TransactionEventInput @doc(category: "Payments") {
@@ -22790,6 +22847,13 @@ input TransactionUpdateInput @doc(category: "Payments") {
   The url that will allow to redirect user to payment provider page with transaction event details.
   """
   externalUrl: String
+
+  """
+  Details of the payment method used for the transaction.
+  
+  Added in Saleor 3.22.
+  """
+  paymentMethodDetails: PaymentMethodDetailsInput
 }
 
 """
@@ -22899,56 +22963,6 @@ enum TransactionEventReportErrorCode @doc(category: "Payments") {
   INCORRECT_DETAILS
   ALREADY_EXISTS
   REQUIRED
-}
-
-"""
-Details of the payment method used for the transaction. One of `card` or `other` is required.
-
-Added in Saleor 3.22.
-"""
-input PaymentMethodDetailsInput {
-  """Details of the card payment method used for the transaction."""
-  card: CardPaymentMethodDetailsInput
-
-  """Details of the non-card payment method used for this transaction."""
-  other: OtherPaymentMethodDetailsInput
-}
-
-input CardPaymentMethodDetailsInput {
-  """
-  Name of the payment method used for the transaction. Max length is 256 characters.
-  """
-  name: String!
-
-  """
-  Brand of the payment method used for the transaction. Max length is 40 characters.
-  """
-  brand: String
-
-  """
-  First digits of the card used for the transaction. Max length is 4 characters.
-  """
-  firstDigits: String
-
-  """
-  Last digits of the card used for the transaction. Max length is 4 characters.
-  """
-  lastDigits: String
-
-  """
-  Expiration month of the card used for the transaction. Value must be between 1 and 12.
-  """
-  expMonth: Int
-
-  """
-  Expiration year of the card used for the transaction. Value must be between 2000 and 9999.
-  """
-  expYear: Int
-}
-
-input OtherPaymentMethodDetailsInput {
-  """Name of the payment method used for the transaction."""
-  name: String!
 }
 
 """


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17830

I want to merge this change because it extends `transactionCreate` mutation.

Mutation now accepts optional paymentMethodDetails input. The input contains the fileds for two type of payment method details:

- card
- other

Note: The PR also changes the grapqhl API for `transactionUpdate`. It is expected, the support for `transactionUpdate` will be provided in separate PR

> [!NOTE]  
> The PR also changes the grapqhl API for `transactionUpdate`. It is expected, the support for `transac...